### PR TITLE
Issue #12 - Fix panic in validation.EnsureString

### DIFF
--- a/util.go
+++ b/util.go
@@ -51,13 +51,13 @@ var (
 
 // EnsureString ensures the given value is a string.
 // If the value is a byte slice, it will be typecast into a string.
-// An error is returned otherwise.
+// An error is returned otherwise. Byte arrays are not supported.
 func EnsureString(value interface{}) (string, error) {
 	v := reflect.ValueOf(value)
 	if v.Kind() == reflect.String {
 		return v.String(), nil
 	}
-	if v.Type() == bytesType {
+	if v.Kind() == reflect.Slice && v.Type() == bytesType {
 		return string(v.Interface().([]byte)), nil
 	}
 	return "", errors.New("must be either a string or byte slice")

--- a/util_test.go
+++ b/util_test.go
@@ -18,7 +18,12 @@ func init() {
 
 func TestEnsureString(t *testing.T) {
 	str := "abc"
-	bytes := []byte("abc")
+	byteSlice := []byte("abc")
+	byteSliceNil := ([]byte)(nil)
+	byteSliceEmpty := []byte{}
+	byteArray := [3]byte{'a', 'b', 'c'}
+	byteArrayEmpty := [0]byte{}
+	intVal := 1
 
 	tests := []struct {
 		tag      string
@@ -28,9 +33,21 @@ func TestEnsureString(t *testing.T) {
 	}{
 		{"t1", "abc", "abc", false},
 		{"t2", &str, "", true},
-		{"t3", bytes, "abc", false},
-		{"t4", &bytes, "", true},
-		{"t5", 100, "", true},
+		{"t3", byteSlice, "abc", false},
+		{"t4", &byteSlice, "", true},
+		{"t5", byteSliceEmpty, "", false},
+		{"t6", &byteSliceEmpty, "", true},
+		{"t7", byteSliceNil, "", false},
+		{"t8", &byteSliceNil, "", true},
+		{"t9", byteArray, "", true},
+		{"t10", &byteArray, "", true},
+		{"t11", byteArrayEmpty, "", true},
+		{"t12", &byteArrayEmpty, "", true},
+		{"t13", 100, "", true},
+		{"t14", (*string)(nil), "", true},
+		{"t15", intVal, "", true},
+		{"t16", &intVal, "", true},
+		{"t17", nil, "", true},
 	}
 	for _, test := range tests {
 		s, err := EnsureString(test.value)


### PR DESCRIPTION
The panic happened because the code was not checking the value's Kind before checking the value's Type