### PR TITLE
Improve `IsEmpty` to check for zero value

### DIFF
--- a/required_test.go
+++ b/required_test.go
@@ -15,6 +15,7 @@ func TestRequired(t *testing.T) {
 	s1 := "123"
 	s2 := ""
 	var time1 time.Time
+	var myStruct MyStruct
 	tests := []struct {
 		tag   string
 		value interface{}
@@ -26,6 +27,8 @@ func TestRequired(t *testing.T) {
 		{"t4", &s2, "cannot be blank"},
 		{"t5", nil, "cannot be blank"},
 		{"t6", time1, "cannot be blank"},
+		{"t7", myStruct, "cannot be blank"},
+		{"t8", &myStruct, "cannot be blank"},
 	}
 
 	for _, test := range tests {
@@ -97,4 +100,8 @@ func TestRequiredRule_Error(t *testing.T) {
 	assert.Equal(t, err.Code(), r.err.Code())
 	assert.Equal(t, err.Message(), r.err.Message())
 	assert.NotEqual(t, err, Required.err)
+}
+
+type MyStruct struct {
+	MyField string
 }

--- a/util.go
+++ b/util.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"time"
 )
 
 // CmpOperator is used to define comparison operators.
@@ -131,16 +130,8 @@ func ToFloat(value interface{}) (float64, error) {
 func IsEmpty(value interface{}) bool {
 	v := reflect.ValueOf(value)
 	switch v.Kind() {
-	case reflect.String, reflect.Array, reflect.Map, reflect.Slice:
+	case reflect.Array, reflect.Map, reflect.Slice:
 		return v.Len() == 0
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
 	case reflect.Invalid:
 		return true
 	case reflect.Interface, reflect.Ptr:
@@ -148,14 +139,9 @@ func IsEmpty(value interface{}) bool {
 			return true
 		}
 		return IsEmpty(v.Elem().Interface())
-	case reflect.Struct:
-		v, ok := value.(time.Time)
-		if ok && v.IsZero() {
-			return true
-		}
+	default:
+		return reflect.DeepEqual(value, reflect.Zero(reflect.TypeOf(value)).Interface())
 	}
-
-	return false
 }
 
 // Indirect returns the value that the given interface or pointer references to.

--- a/util_test.go
+++ b/util_test.go
@@ -272,8 +272,8 @@ func TestIsEmpty(t *testing.T) {
 		{"t8.2", &s2, false},
 		{"t8.3", s3, true},
 		// struct
-		{"t9.1", s4, false},
-		{"t9.2", &s4, false},
+		{"t9.1", s4, true},
+		{"t9.2", &s4, true},
 		// time.Time
 		{"t10.1", time1, false},
 		{"t10.2", &time1, false},


### PR DESCRIPTION
Instead of checking whether a struct value is the zero time, use reflection to compare it against the actual zero value of its type.
We also noticed that `TestIsEmpty` is expecting `struct{}{}` to be not empty. From our point of view this does not really make sense. Therefore we have amended the test to expect `true` for the empty anonymous struct.

@georgethebeatle